### PR TITLE
Fix Exception on Clean build

### DIFF
--- a/AssignAll/AssignAll/CodeFixProvider.cs
+++ b/AssignAll/AssignAll/CodeFixProvider.cs
@@ -32,7 +32,9 @@ namespace AssignAll
         {
             SyntaxNode root =
                 await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            Diagnostic diagnostic = context.Diagnostics.First();
+            Diagnostic diagnostic = context.Diagnostics.FirstOrDefault();
+            if (diagnostic == default)
+                return;
             TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
 
             // Read unassigned member names, passed on from diagnostic

--- a/AssignAll/AssignAll/CodeFixProvider.cs
+++ b/AssignAll/AssignAll/CodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace AssignAll
             SyntaxNode root =
                 await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             Diagnostic diagnostic = context.Diagnostics.FirstOrDefault();
-            if (diagnostic == default)
+            if (diagnostic == null)
                 return;
             TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
 


### PR DESCRIPTION
Installed this into my dotnet standard 2.1 library.  Works really well!
However on a clean build, we run into an exception.  This happens without fail.
After running build a second time (without clean), compilation is all good.

```
Build FAILED.

CSC : error AD0001: Analyzer 'AssignAll.AssignAll_Analyzer' threw an exception of type 'System.InvalidOperationException' with message 'Sequence contains no elements'. [/home/liam/IdeaProjects/citrus/mono-project/BigReporting/BigReporting.Model/BigReporting.Model.csproj]
CSC : error AD0001: Analyzer 'AssignAll.AssignAll_Analyzer' threw an exception of type 'System.InvalidOperationException' with message 'Sequence contains no elements'. [/home/liam/IdeaProjects/citrus/mono-project/BigReporting/BigReporting.Model/BigReporting.Model.csproj]
    0 Warning(s)
    2 Error(s)
```