### PR TITLE
Fix the issue with "Sequence contains no elements" on top-level statements

### DIFF
--- a/AssignAll/AssignAll.Test/UnitTests.cs
+++ b/AssignAll/AssignAll.Test/UnitTests.cs
@@ -33,6 +33,11 @@ namespace AssignAll.Test
             return expected;
         }
 
+        private static DiagnosticResult GetMissingAssignmentDiagnosticResult(int line = 9, int column = 23, params string[] unassignedMemberNames)
+        {
+            return GetMissingAssignmentDiagnosticResult("Foo", line, column, 0, unassignedMemberNames);
+        }
+
         private static DiagnosticResult GetMissingAssignmentDiagnosticResult(params string[] unassignedMemberNames)
         {
             // Most code snippets in the tests are identical up to the object initializer
@@ -91,7 +96,7 @@ namespace SampleConsoleApp
                 // Commented assignments after opening brace.
                 // PropCommented1 = 1,
 
-                // Assigned property, OK'ed by analyzer
+                // Assigned property, OK by analyzer
                 PropAssigned = 1,
 
                 // Commented assignments just before closing brace
@@ -545,7 +550,7 @@ namespace SampleConsoleApp
             // AssignAll enable
             var foo = new Foo
             {
-                // ProtInt and PropString not assigned, diagnostic error
+                // PropInt and PropString not assigned, diagnostic error
             };
         }
 
@@ -558,6 +563,30 @@ namespace SampleConsoleApp
 }
 ";
             DiagnosticResult expected = GetMissingAssignmentDiagnosticResult("PropInt", "PropString");
+            VerifyCSharpDiagnostic(testContent, expected);
+        }
+
+        [Fact]
+        public void PropertiesNotAssigned_InFileWithTopLevelStatements_AddsDiagnosticWithPropertyNames()
+        {
+            var testContent = @"
+// AssignAll enable
+var foo = new Foo
+{
+    // PropInt and PropString not assigned, diagnostic error
+};
+
+// Add methods and nested types available to top level statements via a partial Program class.
+public static partial class Program
+{
+    private class Foo
+    {
+        public int PropInt { get; set; }
+        public string PropString { get; set; }
+    }
+}
+";
+            DiagnosticResult expected = GetMissingAssignmentDiagnosticResult(line: 3, column: 11, "PropInt", "PropString");
             VerifyCSharpDiagnostic(testContent, expected);
         }
 

--- a/AssignAll/AssignAll/AssignAllAnalyzer.cs
+++ b/AssignAll/AssignAll/AssignAllAnalyzer.cs
@@ -65,7 +65,7 @@ namespace AssignAll
 
         private RegionsToAnalyze GetOrSetCachedRegionsToAnalyzeInFile(SyntaxNode codeBlock)
         {
-            SyntaxNode rootNode = codeBlock.Ancestors().Last();
+            SyntaxNode rootNode = codeBlock.Ancestors().LastOrDefault() ?? codeBlock;
             SyntaxReference rootNodeRef = rootNode.GetReference();
 
             if (_rootNodeToAnalyzerTextSpans.TryGetValue(rootNodeRef, out RegionsToAnalyze regionsToAnalyze))


### PR DESCRIPTION
Hi @angularsen!

Thank you for such a useful code analyzer: I was about to write something like this by myself when I realized there is one already :)

On our project though we found that, from time to time, the code analyzer fails with the error
```
  Analyzer "AssignAll.AssignAllAnalyzer" raised an exception "System.InvalidOperationException" with message "Sequence contains no elements".
```
As we found out, this happens when it tries to analyze a file with top-level statements (Program.cs, in our case). `codeBlock` passed into the `GetOrSetCachedRegionsToAnalyzeInFile` method has type `CompilationUnitSyntax`, and its `Ancestors()` collection is empty, therefore, 
```
 codeBlock.Ancestors().Last();
```
raises the exception.

This does not happen all the time (due to caching, maybe?), and I was unable to reproduce the issue in unit tests, but it seems, the provided fix solves the issue. With the proposed approach, if there are no ancestors for the `codeBlock`, it is used as the root on its own.