### PR TITLE
Allow spacing in AssignAll comments

### DIFF
--- a/AssignAll/AssignAll.Test/UnitTests.cs
+++ b/AssignAll/AssignAll.Test/UnitTests.cs
@@ -118,28 +118,30 @@ namespace SampleConsoleApp
             await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
-        [Fact]
-        public async Task EnableAndDisableComments_EnablesAndDisablesAnalyzerForTextSpans()
+        [Theory]
+        [InlineData("// AssignAll")]
+        [InlineData("//AssignAll")]
+        public async Task EnableAndDisableComments_EnablesAndDisablesAnalyzerForTextSpans(string commentStart)
         {
-            var test = @"
+            var code = @"
 namespace SampleConsoleApp
 {
     internal static class Program
     {
         private static void Main(string[] args)
         {
-            // AssignAll enable
+            {commentStart} enable
             Foo foo = {|#0:new Foo
             {
                 // PropInt not assigned, diagnostic error
 
-                // AssignAll disable
+                {commentStart} disable
                 Bar = new Bar
                 {
                     // PropInt not assigned, but analyzer is disabled, no diagnostic error
 
                     // Re-enable analyzer for Baz creation
-                    // AssignAll enable
+                    {commentStart} enable
                     Baz = {|#1:new Baz
                     {
                         // PropInt not assigned, diagnostic error
@@ -165,8 +167,9 @@ namespace SampleConsoleApp
             public int PropInt { get; set; }
         }
     }
-}        
+}
 ";
+            var test = code.Replace("{commentStart}", commentStart);
 
             // Bar type has no diagnostic errors
             await VerifyCS.VerifyAnalyzerAsync(test,

--- a/AssignAll/AssignAll.Test/UnitTests.cs
+++ b/AssignAll/AssignAll.Test/UnitTests.cs
@@ -119,10 +119,19 @@ namespace SampleConsoleApp
         }
 
         [Theory]
-        [InlineData("// AssignAll")]
-        [InlineData("//AssignAll")]
-        public async Task EnableAndDisableComments_EnablesAndDisablesAnalyzerForTextSpans(string commentStart)
+        [InlineData("// {0}")]
+        [InlineData("//{0}")]
+        [InlineData("//{0} ")]
+        [InlineData("// {0} ")]
+        [InlineData("//\t{0}")]
+        [InlineData("//\t{0}\t")]
+        [InlineData("//     {0}      ")]
+        [InlineData("//  \t \t    {0}   \t\t  ")]
+        public async Task EnableAndDisableComments_EnablesAndDisablesAnalyzerForTextSpans(string commentTemplate)
         {
+            string enableComment = string.Format(commentTemplate, "AssignAll enable");
+            string disableComment = string.Format(commentTemplate, "AssignAll disable");
+
             var code = @"
 namespace SampleConsoleApp
 {
@@ -130,18 +139,18 @@ namespace SampleConsoleApp
     {
         private static void Main(string[] args)
         {
-            {commentStart} enable
+            {enableComment}
             Foo foo = {|#0:new Foo
             {
                 // PropInt not assigned, diagnostic error
 
-                {commentStart} disable
+                {disableComment}
                 Bar = new Bar
                 {
                     // PropInt not assigned, but analyzer is disabled, no diagnostic error
 
                     // Re-enable analyzer for Baz creation
-                    {commentStart} enable
+                    {enableComment}
                     Baz = {|#1:new Baz
                     {
                         // PropInt not assigned, diagnostic error
@@ -169,7 +178,8 @@ namespace SampleConsoleApp
     }
 }
 ";
-            var test = code.Replace("{commentStart}", commentStart);
+            var test = code.Replace("{enableComment}", enableComment)
+                .Replace("{disableComment}", disableComment);
 
             // Bar type has no diagnostic errors
             await VerifyCS.VerifyAnalyzerAsync(test,

--- a/AssignAll/AssignAll/AssignAllMembers/RegionsToAnalyzeProvider.cs
+++ b/AssignAll/AssignAll/AssignAllMembers/RegionsToAnalyzeProvider.cs
@@ -10,8 +10,8 @@ namespace AssignAll.AssignAllMembers
 {
     internal static class RegionsToAnalyzeProvider
     {
-        private static readonly Regex AssignAllDisableRegex = new Regex(@"^// AssignAll disable$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex AssignAllEnableRegex = new Regex(@"^// AssignAll enable$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AssignAllDisableRegex = new Regex(@"^// ?AssignAll disable$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AssignAllEnableRegex = new Regex(@"^// ?AssignAll enable$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         internal static RegionsToAnalyze GetRegionsToAnalyze(SyntaxNode rootNode)
         {

--- a/AssignAll/AssignAll/AssignAllMembers/RegionsToAnalyzeProvider.cs
+++ b/AssignAll/AssignAll/AssignAllMembers/RegionsToAnalyzeProvider.cs
@@ -10,8 +10,8 @@ namespace AssignAll.AssignAllMembers
 {
     internal static class RegionsToAnalyzeProvider
     {
-        private static readonly Regex AssignAllDisableRegex = new Regex(@"^// ?AssignAll disable$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex AssignAllEnableRegex = new Regex(@"^// ?AssignAll enable$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AssignAllDisableRegex = new Regex(@"^//\s*AssignAll disable\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AssignAllEnableRegex = new Regex(@"^//\s*AssignAll enable\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         internal static RegionsToAnalyze GetRegionsToAnalyze(SyntaxNode rootNode)
         {


### PR DESCRIPTION
It seems that upgrading to 1.6.0 and above can break the detection of AssignAll regions. Earlier versions allow for arbitrary spacing between `//` and `AssignAll` (see 8866208). So if one has comments like this: `//AssignAll enable` and upgrades to the higher versions, the analyzer will stop working in a rather unnoticeable fashion.

I prepared a small fix for the no space case. Other possible cases with multiple spaces or tabs are not covered, but I guess they are less probable.