### PR TITLE
✨Exclude inaccessible property setters and fields

### DIFF
--- a/AssignAll/AssignAll.Test/CodeFixTests.cs
+++ b/AssignAll/AssignAll.Test/CodeFixTests.cs
@@ -51,16 +51,16 @@ namespace SampleConsoleApp
             // AssignAll enable
             Foo foo = new Foo
             {
+                FieldBool = ,
                 PropInt = ,
-                PropString = ,
-                FieldBool = 
+                PropString = 
             };
         }
     }
 }
 ";
             // Ignore compile errors in the fixed code, it is intentional to force user to fix it.
-            var expected = VerifyCS.Diagnostic("AssignAll").WithLocation(0).WithArguments("Foo", "PropInt, PropString, FieldBool");
+            var expected = VerifyCS.Diagnostic("AssignAll").WithLocation(0).WithArguments("Foo", "FieldBool, PropInt, PropString");
             await VerifyCS.VerifyCodeFixAsync(testCode, expected, fixedCode, t => t.CompilerDiagnostics = CompilerDiagnostics.None);
         }
 

--- a/AssignAll/AssignAll.Test/UnitTests.cs
+++ b/AssignAll/AssignAll.Test/UnitTests.cs
@@ -477,41 +477,6 @@ namespace SampleConsoleApp
             await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
-        /// <remarks>
-        ///     TODO Revisit this when the implementation supports looking at the calling context to determine if internal, protected and private setters can be assigned.
-        /// </remarks>
-        [Fact]
-        public async Task NonPublicFieldsNotAssigned_AddsNoDiagnostics()
-        {
-            string[] accessModifiers = {"private", "internal", "protected", "protected internal"};
-            foreach (var accessModifier in accessModifiers)
-            {
-                var test = @"
-namespace SampleConsoleApp
-{
-    internal static class Program
-    {
-        private static void Main(string[] args)
-        {
-            // AssignAll enable
-            var foo = new Foo
-            {
-                // FieldInt not assigned, diagnostic currently limited to public only, so all other access modifiers will be ignored
-            };
-        }
-
-        private class Foo
-        {
-            {{accessModifier}} int FieldInt;
-        }
-    }
-}
-".Replace("{{accessModifier}}", accessModifier);
-
-                await VerifyCS.VerifyAnalyzerAsync(test);
-            }
-        }
-
         [Fact]
         public async Task UnassignedMembers_OutsideClass_ExcludesProtectedAndPrivateMembers()
         {

--- a/AssignAll/AssignAll/AssignAllMembers/ObjectInitializerAnalyzer.cs
+++ b/AssignAll/AssignAll/AssignAllMembers/ObjectInitializerAnalyzer.cs
@@ -56,12 +56,18 @@ namespace AssignAll.AssignAllMembers
             IEnumerable<ISymbol> assignableProperties = members
                 .OfType<IPropertySymbol>()
                 .Where(m =>
+                {
                     // Exclude indexer properties
-                    !m.IsIndexer &&
-                    // Exclude read-only getter properties
-                    !m.IsReadOnly &&
-                    // Simplification, only care about public members
-                    m.DeclaredAccessibility == Accessibility.Public);
+                    return !m.IsIndexer &&
+                           // Exclude read-only getter properties
+                           !m.IsReadOnly &&
+                           // Simplification, only care about public members
+                           m.DeclaredAccessibility == Accessibility.Public &&
+                           // Try to determine if setter is accessible from the calling context, such as assigning private setters from within the class itself.
+                           m.SetMethod != null &&
+                           ctx.SemanticModel.IsAccessible(objectInitializer.SpanStart, m.SetMethod);
+                });
+
 
             IEnumerable<ISymbol> assignableFields = members.OfType<IFieldSymbol>()
                 .Where(m =>

--- a/Samples.ConsoleNet6/Example006_IgnoreInaccessibleMembers.cs
+++ b/Samples.ConsoleNet6/Example006_IgnoreInaccessibleMembers.cs
@@ -1,0 +1,39 @@
+// AssignAll enable
+// EXAMPLE 006 - Exclude properties with private/protected setters and fields that are not accessible.
+namespace Samples.ConsoleNet6;
+
+internal static class Program
+{
+    private static void Main(string[] args)
+    {
+        // Gives analyzer error for all members except private setters and fields, since they are not accessible.
+        // Missing member assignments in object initializer for type 'Foo'. Properties: PublicSetter, InternalSetter, ProtectedInternalSetter, PrivateSetter, PublicField, InternalField, ProtectedInternalField, PrivateField
+        Foo foo = new()
+        {
+        };
+    }
+
+    private class Foo
+    {
+        public int PublicSetter { get; set; }
+        public int InternalSetter { get; internal set; }
+        public int ProtectedInternalSetter { get; protected internal set; }
+        public int ProtectedSetter { get; protected set; }
+        public int PrivateSetter { get; private set; }
+
+        public int PublicField;
+        internal int InternalField;
+        protected internal int ProtectedInternalField;
+        protected int ProtectedField;
+        private int PrivateField;
+
+        private Foo MethodWithAccessToPrivateMembers()
+        {
+            // Gives analyzer error for all members, including private setters and fields, since they are accessible.
+            // Missing member assignments in object initializer for type 'Foo'. Properties: InternalField, InternalSetter, PrivateField, PrivateSetter, ProtectedInternalField, ProtectedInternalSetter, PublicSetter, PublicField
+            return new Foo
+            {
+            };
+        }
+    }
+}


### PR DESCRIPTION
Ignore unassigned `private` and `protected` property setters and fields, when assigning members outside the class. They are not allowed to be assigned anyway.

Same with `internal` if assigned from outside the project, but this is probably more rare.